### PR TITLE
Highlight variable declarations

### DIFF
--- a/languages/http/highlights.scm
+++ b/languages/http/highlights.scm
@@ -20,7 +20,17 @@
 ; Highlight HTTP versions
 (http_version) @keyword
 
-; Highlight variables and script variables
+; Highlight variable declarations (@foo=bar)
+(variable_declaration
+  name: (identifier) @variable)
+(variable_declaration
+  value: (string) @string)
+(variable_declaration
+  value: (number) @number)
+(variable_declaration
+  value: (boolean) @boolean)
+
+; Highlight variables and script variables ({{foo}})
 (variable) @variable
 (script_variable) @variable.special
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -13,7 +13,7 @@ impl zed::Extension for HttpExtension {
         _: &zed_extension_api::LanguageServerId,
         _: &zed_extension_api::Worktree,
     ) -> zed_extension_api::Result<zed_extension_api::Command> {
-        Err(("Not implmented").into())
+        Err(("Not implemented").into())
     }
 }
 

--- a/test/test.http
+++ b/test/test.http
@@ -43,7 +43,7 @@ Accept: application/json
 
 
 ### PATCH Request with XML Body
-PATCH http://example.com/api/users/123
+PATCH http://example.com/api/users/{{user_id}}
 Content-Type: application/xml
 Authorization: Bearer your_access_token_here
 
@@ -52,3 +52,12 @@ Authorization: Bearer your_access_token_here
   <email>update@example.com</email>
   <status>active</status>
 </user>
+
+
+###
+# variables
+
+@user_id=123
+@number_variable=456
+@string_variable="fooBar"
+@boolean_variable=false


### PR DESCRIPTION
* Highlights variable declarations in the editor pane
* Highlights different types of variables: number, string, boolean (note string variable support differs between http clients)
     * adds examples of these variables to the `test/test.http` file (see screenshots below)
* (And a totally unrelated typo fix in 558003ab0b30117dd60fb7c3fbbbe9f468faf225)


## screenshots: 


After: 

<img width="377" height="215" alt="image" src="https://github.com/user-attachments/assets/c00fa9c1-67f1-476f-9d27-a3c84d5851cd" />


Before:

<img width="385" height="208" alt="image" src="https://github.com/user-attachments/assets/29dfe32a-2ed6-4389-9b21-1b4ab0567f9f" />


